### PR TITLE
fix: minor ui mismatch issues

### DIFF
--- a/packages/frontend/src/components/commons/Address.tsx
+++ b/packages/frontend/src/components/commons/Address.tsx
@@ -14,7 +14,7 @@ const shortAddress = (addr: string): string =>
     : addr;
 
 const Address = ({ address, className }: AddressProps): JSX.Element => {
-  const { isLoading, domain, resolveDomainName } = useDomainName();
+  const { domain, resolveDomainName } = useDomainName();
   const { getContactNameByAddress } = useUserContact();
 
   resolveDomainName(address);
@@ -24,20 +24,24 @@ const Address = ({ address, className }: AddressProps): JSX.Element => {
   return (
     <span className={classNames(className || '', 'font-mono')} title={address}>
       <>
-        {(domain?.ensName && (
-          <img
-            className="h-4 mr-1 w-auto inline-block"
-            src="/ens-icon.png"
-            alt="ENS"
-          />
-        )) ||
+        {nickname === undefined ? (
+          (domain?.ensName && (
+            <img
+              className="h-4 mr-1 w-auto inline-block"
+              src="/ens-icon.png"
+              alt="ENS"
+            />
+          )) ||
           (domain?.udName && (
             <img
               className="h-4 mr-1 w-auto inline-block"
               src="/ud-icon.png"
               alt="UD"
             />
-          ))}
+          ))
+        ) : (
+          <></>
+        )}
 
         {nickname || domain?.ensName || domain?.udName || shortAddress(address)}
       </>

--- a/packages/frontend/src/components/commons/AddressPill.tsx
+++ b/packages/frontend/src/components/commons/AddressPill.tsx
@@ -22,11 +22,12 @@ const AddressPill = ({
         'px-2',
         'py-1',
         'font-bold',
-        userIsSender ? 'bg-bt-100 text-b-600' : 'bg-zinc-50',
+        'text-b-600',
+        userIsSender ? 'bg-bt-100' : 'bg-zinc-50',
         userIsSender ? 'border-bt-300' : 'border-gray-300'
       )}
       address={address}
-    ></Address>
+    />
   );
 };
 

--- a/packages/frontend/src/components/commons/Avatar.tsx
+++ b/packages/frontend/src/components/commons/Avatar.tsx
@@ -6,7 +6,7 @@ type AvatarProps = {
   addressOrName: string;
 };
 
-const Avatar = ({ addressOrName }: AvatarProps) => {
+const Avatar: React.FC<AvatarProps> = ({ addressOrName }) => {
   const { ensAvatar, isLoadingAvatar } = useEns(addressOrName);
   return ensAvatar && !isLoadingAvatar ? (
     <img
@@ -15,7 +15,15 @@ const Avatar = ({ addressOrName }: AvatarProps) => {
       alt={addressOrName}
     />
   ) : (
-    <Blockies seed={addressOrName} size={10} className="rounded-full" />
+    /**
+     * The toLowerCase here is needed to generate a consistent avatar regardless of
+     * the casing.
+     */
+    <Blockies
+      seed={addressOrName.toLowerCase()}
+      size={10}
+      className="rounded-full"
+    />
   );
 };
 

--- a/packages/frontend/src/components/commons/UserMenu.tsx
+++ b/packages/frontend/src/components/commons/UserMenu.tsx
@@ -1,3 +1,4 @@
+import { Avatar } from '@chakra-ui/react';
 import { Menu, Transition } from '@headlessui/react';
 import { classNames } from '@helpers/classNames';
 import { CogIcon } from '@heroicons/react/solid';
@@ -20,17 +21,20 @@ type AvatarBlockProps = {
 
 const AvatarBlock = ({ addressOrName }: AvatarBlockProps) => {
   const { data: ensAvatar } = useEnsAvatar({ addressOrName });
+
+  // Make the address lowercase so that the blockies is consistent
+  const lowerCasedAddressOrName = addressOrName.toLowerCase()
+
   return ensAvatar ? (
     <img
       className={'rounded-full h-8 w-8 mr-2'}
       src={ensAvatar}
-      alt={addressOrName}
+      alt={lowerCasedAddressOrName}
     />
   ) : (
-    <Blockies seed={addressOrName} size={8} className="rounded-full mr-2" />
+    <Blockies seed={lowerCasedAddressOrName} size={8} className="rounded-full mr-2" />
   );
 };
-
 const NotConnected = (): JSX.Element => {
   return (
     <>

--- a/packages/frontend/src/components/conversation/RecipientControl.tsx
+++ b/packages/frontend/src/components/conversation/RecipientControl.tsx
@@ -2,7 +2,7 @@ import AddressInput from '@components/commons/AddressInput';
 import AddToContactModal from '@components/Modals/AddToContactModal';
 import { useDomainName } from '@hooks/useDomainName';
 import { useRouter } from 'next/router';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import useXmtp from '../../hooks/useXmtp';
 
@@ -23,42 +23,33 @@ const RecipientControl = ({
   peerAddressOrName,
   onSubmit,
 }: RecipientInputProps): JSX.Element => {
-  const { client } = useXmtp();
   const router = useRouter();
+
   const [recipientInputMode, setRecipientInputMode] = useState(
     RecipientInputMode.InvalidEntry
   );
   const [pendingPeerAddressOrName, setPendingPeerAddressOrName] =
-    useState<string>('');
+    useState<string>(peerAddressOrName || '');
 
+  const { client } = useXmtp();
   const { isLoading, domain, resolveDomainName } = useDomainName();
+
   resolveDomainName(pendingPeerAddressOrName);
 
-  const checkIfOnNetwork = useCallback(
-    async (pendingAddress: string): Promise<boolean> => {
-      return client?.canMessage(pendingAddress) || false;
-    },
-    [client]
-  );
+  const checkIfOnNetwork = async (pendingAddress: string): Promise<boolean> => {
+    return client?.canMessage(pendingAddress) || false;
+  };
 
-  const completeSubmit = useCallback(async () => {
+  const completeSubmit = async () => {
     const checkAddress = domain?.ensAddress || domain?.udAddress;
+    console.log('check', checkAddress, domain);
     if (await checkIfOnNetwork(checkAddress as string)) {
       onSubmit(checkAddress as string);
       setRecipientInputMode(RecipientInputMode.Submitted);
     } else {
       setRecipientInputMode(RecipientInputMode.NotOnNetwork);
     }
-  }, [checkIfOnNetwork, domain, onSubmit]);
-
-  // const completeSubmit = useCallback(async () => {
-  //   if (await checkIfOnNetwork(pendingAddress as string)) {
-  //     onSubmit(pendingPeerAddressOrName);
-  //     setRecipientInputMode(RecipientInputMode.Submitted);
-  //   } else {
-  //     setRecipientInputMode(RecipientInputMode.NotOnNetwork);
-  //   }
-  // }, [checkIfOnNetwork, pendingAddress, pendingPeerAddressOrName, onSubmit]);
+  };
 
   useEffect(() => {
     const handleRecipientInput = () => {
@@ -78,18 +69,16 @@ const RecipientControl = ({
     peerAddressOrName,
     isLoading,
     pendingPeerAddressOrName,
+    setPendingPeerAddressOrName,
     setRecipientInputMode,
-    completeSubmit,
   ]);
 
-  const handleSubmit = (e: React.SyntheticEvent, value?: string) => {
-    e.preventDefault();
-    const data = e.target as typeof e.target & {
-      input: { value: string };
-    };
-    const inputValue = value || data.input.value;
-    setPendingPeerAddressOrName(inputValue);
-  };
+  useEffect(() => {
+    if (domain !== undefined) {
+      completeSubmit();
+      setPendingPeerAddressOrName('');
+    }
+  }, [domain, setPendingPeerAddressOrName]);
 
   const handleInputChange = (e: React.SyntheticEvent) => {
     const data = e.target as typeof e.target & {
@@ -98,13 +87,14 @@ const RecipientControl = ({
     if (router.pathname !== '/dm/') {
       router.push('/dm');
     }
+
     if (
       data.value.endsWith('.eth') ||
       data.value.endsWith('.wallet') || //TODO: add more domains
       (data.value.startsWith('0x') && data.value.length === 42)
     ) {
-      setPendingPeerAddressOrName(data.value);
-      handleSubmit(e, data.value);
+      setPendingPeerAddressOrName(data.value)
+      resolveDomainName(data.value);
     } else {
       setRecipientInputMode(RecipientInputMode.InvalidEntry);
     }
@@ -115,8 +105,7 @@ const RecipientControl = ({
       <form
         className="w-full flex pl-2 md:pl-0 h-8 pt-1"
         action="#"
-        method="GET"
-        onSubmit={handleSubmit}
+        onSubmit={(e) => e.preventDefault()}
       >
         <label htmlFor="recipient-field" className="sr-only">
           Recipient
@@ -126,7 +115,7 @@ const RecipientControl = ({
             To:
           </div>
           <AddressInput
-            peerAddressOrName={peerAddressOrName}
+            peerAddressOrName={peerAddressOrName?.toLowerCase() || ''}
             id="recipient-field"
             className="block w-[95%] pl-7 pr-3 pt-[3px] md:pt-[2px] md:pt-[1px] bg-transparent caret-n-600 text-n-600 placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-0 focus:border-transparent text-lg font-mono"
             name="recipient"

--- a/packages/frontend/src/components/layouts/ChatLayout.tsx
+++ b/packages/frontend/src/components/layouts/ChatLayout.tsx
@@ -72,14 +72,19 @@ const ConversationLayout: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
   const router = useRouter();
-  const peerAddressOrName = router.query.peerAddressOrName as string;
+  const [peerAddressOrName, setPeerAddressOrName] = useState<string>();
 
-  const handleSubmit = useCallback(
-    async (peerAddressOrName: string) => {
-      router.push(peerAddressOrName ? `/dm/${peerAddressOrName}` : '/dm/');
-    },
-    [router]
-  );
+  useEffect(() => {
+    const curAddress = router.query.peerAddressOrName;
+    if (curAddress && typeof curAddress === 'string') {
+      setPeerAddressOrName(curAddress);
+    }
+  }, [router]);
+
+  const handleSubmit = async (newPeerAddressOrName: string) => {
+    setPeerAddressOrName(newPeerAddressOrName);
+    router.push(newPeerAddressOrName ? `/dm/${newPeerAddressOrName}` : '/dm/');
+  };
 
   const handleBackArrowClick = useCallback(() => {
     router.push('/');


### PR DESCRIPTION
- Nickname should not have logos from ENS or UDS
- .eth as address input should resolve successfully in one go instead of requiring you to reenter
- transfer should now properly show up with its address text shown
- avatar generated from blockies should now be more consistent, along with the displayed address' casing.